### PR TITLE
Use ASCCONV from Phoenix header

### DIFF
--- a/src/io_twix.jl
+++ b/src/io_twix.jl
@@ -333,13 +333,16 @@ function load_twix(io::IO; header_only=false, acquisition_filter=(acq)->true,
     @debug "Header section names" keys(header_sections)
     metadata = Dict{String,Any}()
     try
-        yaps_meta = parse_header_yaps(header_sections["MeasYaps"])
+        phoenix_ascconv = match(r"(### ASCCONV BEGIN.*### ASCCONV END ###)"s,
+                                header_sections["Phoenix"]).captures[1]
+        # yaps_meta = parse_header_yaps(header_sections["MeasYaps"])
+        phoenix_ascconv_meta = parse_header_yaps(phoenix_ascconv)
         dicom_meta = match_xprot_header(header_sections["Dicom"], "Dicom.",
                                         ["SoftwareVersions", "DeviceSerialNumber", "InstitutionName", "Manufacturer", "ManufacturersModelName"])
         meas_meta  = match_xprot_header(header_sections["Meas"], "Meas.",
                                         ["tReferenceImage0", "tReferenceImage1", "tReferenceImage2",
                                          "tFrameOfReference"])
-        metadata = merge(metadata, yaps_meta, dicom_meta, meas_meta)
+        metadata = merge(metadata, phoenix_ascconv_meta, dicom_meta, meas_meta)
     catch exc
         @error "Could not parse header metadata" exception=(exc,catch_backtrace())
     end

--- a/src/io_twix.jl
+++ b/src/io_twix.jl
@@ -339,14 +339,19 @@ function load_twix(io::IO; header_only=false, acquisition_filter=(acq)->true,
         phoenix_ascconv_meta = parse_header_yaps(phoenix_ascconv)
 
         # Check if the same key has different value in yaps and phoenix to warn user
+        differences = Dict()
         for k in intersect(Set(keys(yaps_meta)), Set(keys(phoenix_ascconv_meta)))
             if yaps_meta[k] != phoenix_ascconv_meta[k]
-                @warn """
-                      Key $k has different value in MeasYaps and Phoenix ASCCONV section. As per
-                      our testing in getting the correct frequency, MeasYaps sometimes is not
-                      consistent with other sections, so this metadata is extracted from Phoenix.
-                      """ yaps_meta=yaps_meta[k] phoenix_ascconv_meta=phoenix_ascconv_meta[k]
+                differences[k] = (MeasYapsASCCONV=yaps_meta[k],
+                                  PhoenixASCCONV=phoenix_ascconv_meta[k])
             end
+        end
+        if length(differences) > 0
+            @warn """
+                  Different values found in MeasYaps and Phoenix ASCCONV section. As per
+                  our testing in getting the correct frequency, MeasYaps sometimes is not
+                  consistent with other sections, so this metadata is extracted from Phoenix.
+                  """ differences
         end
         dicom_meta = match_xprot_header(header_sections["Dicom"], "Dicom.",
                                         ["SoftwareVersions", "DeviceSerialNumber", "InstitutionName", "Manufacturer", "ManufacturersModelName"])

--- a/src/io_twix.jl
+++ b/src/io_twix.jl
@@ -345,7 +345,7 @@ function load_twix(io::IO; header_only=false, acquisition_filter=(acq)->true,
                       Key $k has different value in MeasYaps and Phoenix ASCCONV section. As per
                       our testing in getting the correct frequency, MeasYaps sometimes is not
                       consistent with other sections, so this metadata is extracted from Phoenix.
-                      """ yaps_meta[k] phoenix_ascconv_meta[k]
+                      """ yaps_meta=yaps_meta[k] phoenix_ascconv_meta=phoenix_ascconv_meta[k]
             end
         end
         dicom_meta = match_xprot_header(header_sections["Dicom"], "Dicom.",

--- a/test/io_twix.jl
+++ b/test/io_twix.jl
@@ -85,6 +85,10 @@ end
 
 @testset "twix quality control" begin
     twix = @test_logs (Logging.Warn,r"Unexpected empty meas packet") #=
+               =# (Logging.Warn,r"Key lSequenceID has different") #=
+               =# (Logging.Warn,r"Key lPtabAbsStartPosZ has different") #=
+               =# (Logging.Warn,r"Key bPtabAbsStartPosZValid has different") #=
+               =# (Logging.Warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
                =# load_twix("twix/sub-SiemensBrainPhantom_seq-svslcosy_incomplete.twix")
     @test MagneticResonanceSignals.AcquisitionsIncomplete in twix.quality_control
 
@@ -99,6 +103,10 @@ end
     truncated_twix = copy(valid_twix_bytes)
     truncated_twix = truncated_twix[1:900_000]
     twix = @test_logs (Logging.Warn,r"Twix acquisition truncated at position 900000") #=
+        =# (Logging.Warn,r"Key lSequenceID has different") #=
+        =# (Logging.Warn,r"Key lPtabAbsStartPosZ has different") #=
+        =# (Logging.Warn,r"Key bPtabAbsStartPosZValid has different") #=
+        =# (Logging.Warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
         =# load_twix(IOBuffer(truncated_twix))
     @test MagneticResonanceSignals.AcquisitionsIncomplete in twix.quality_control
 end

--- a/test/io_twix.jl
+++ b/test/io_twix.jl
@@ -85,10 +85,7 @@ end
 
 @testset "twix quality control" begin
     twix = @test_logs (Logging.Warn,r"Unexpected empty meas packet") #=
-               =# (Logging.Warn,r"Key lSequenceID has different") #=
-               =# (Logging.Warn,r"Key lPtabAbsStartPosZ has different") #=
-               =# (Logging.Warn,r"Key bPtabAbsStartPosZValid has different") #=
-               =# (Logging.Warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
+               =# (Logging.Warn,r"Different values found in MeasYaps") #=
                =# load_twix("twix/sub-SiemensBrainPhantom_seq-svslcosy_incomplete.twix")
     @test MagneticResonanceSignals.AcquisitionsIncomplete in twix.quality_control
 
@@ -103,10 +100,7 @@ end
     truncated_twix = copy(valid_twix_bytes)
     truncated_twix = truncated_twix[1:900_000]
     twix = @test_logs (Logging.Warn,r"Twix acquisition truncated at position 900000") #=
-        =# (Logging.Warn,r"Key lSequenceID has different") #=
-        =# (Logging.Warn,r"Key lPtabAbsStartPosZ has different") #=
-        =# (Logging.Warn,r"Key bPtabAbsStartPosZValid has different") #=
-        =# (Logging.Warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
+        =# (Logging.Warn,r"Different values found in MeasYaps") #=
         =# load_twix(IOBuffer(truncated_twix))
     @test MagneticResonanceSignals.AcquisitionsIncomplete in twix.quality_control
 end

--- a/test/mr_load.jl
+++ b/test/mr_load.jl
@@ -2,10 +2,7 @@ using Logging
 
 @testset "mr_load integration test" begin
     # TODO: This is far too trivial! should get / generate some better test data.
-    cosy = @test_logs (:warn,r"Key lSequenceID has different") #=
-        =# (:warn,r"Key lPtabAbsStartPosZ has different") #=
-        =# (:warn,r"Key bPtabAbsStartPosZValid has different") #=
-        =# (:warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
+    cosy = @test_logs (:warn,r"Different values found in MeasYaps") #=
         =# (:warn,r"Sequence.*is not one of the versions I recognize"s) #=
         =# mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
 

--- a/test/mr_load.jl
+++ b/test/mr_load.jl
@@ -2,7 +2,11 @@ using Logging
 
 @testset "mr_load integration test" begin
     # TODO: This is far too trivial! should get / generate some better test data.
-    cosy = @test_logs (:warn,r"Sequence.*is not one of the versions I recognize"s) #=
+    cosy = @test_logs (:warn,r"Key lSequenceID has different") #=
+        =# (:warn,r"Key lPtabAbsStartPosZ has different") #=
+        =# (:warn,r"Key bPtabAbsStartPosZValid has different") #=
+        =# (:warn,r"Key sTXSPEC.B1CorrectionParameters.bValid has different") #=
+        =# (:warn,r"Sequence.*is not one of the versions I recognize"s) #=
         =# mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
 
     @test size(cosy.lcosy_scans) == (1,1)

--- a/test/processing.jl
+++ b/test/processing.jl
@@ -24,7 +24,7 @@ end
 end
 
 @testset "lcosy" begin
-    lcosy = @test_logs (:warn,) (:warn,) (:warn,) (:warn,) (:warn,) mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
+    lcosy = @test_logs (:warn,) (:warn,) mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
 
     signal = simple_averaging(lcosy)
     @test size(signal) == (2048,1)

--- a/test/processing.jl
+++ b/test/processing.jl
@@ -24,7 +24,7 @@ end
 end
 
 @testset "lcosy" begin
-    lcosy = @test_logs (:warn,) mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
+    lcosy = @test_logs (:warn,) (:warn,) (:warn,) (:warn,) (:warn,) mr_load("twix/sub-SiemensBrainPhantom_seq-svslcosy_inc-1.twix")
 
     signal = simple_averaging(lcosy)
     @test size(signal) == (2048,1)


### PR DESCRIPTION
Sometimes MeasYaps TWIX header records different frequency from other headers. (See related issue for more detail)
To fix this, if same key found, the metadata is overwritten by ASCCONV in Phoenix header instead of MeasYaps.

Closes #4 